### PR TITLE
Download images asynchronously before LayoutMachine lays out views.

### DIFF
--- a/Assets/UUebView/Core/DefaultImageDownloader.cs
+++ b/Assets/UUebView/Core/DefaultImageDownloader.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace UUebView
+{
+    public class DefaultImageDownloader
+    {
+        private readonly ResourceLoader resLoader;
+        private readonly List<string> downloadingUris = new List<string>();
+        public readonly Action<IEnumerator> LoadParallel;
+
+        public DefaultImageDownloader(Action<IEnumerator> loadParallel, ResourceLoader resLoader)
+        {
+            this.LoadParallel = loadParallel;
+            this.resLoader = resLoader;
+        }
+
+        // 画像読み込みリクエストを行う
+        public void RequestLoadImage(string uri)
+        {
+            // 同一のuriで既にリクエストが行われている場合は何もしない
+            if (downloadingUris.Contains(uri))
+            {
+                return;
+            }
+
+            // 読込中uriとしてlistに詰める
+            downloadingUris.Add(uri);
+
+            LoadParallel(LoadImageAsync(uri));
+        }
+
+        private IEnumerator LoadImageAsync(string uri)
+        {
+            var cor = resLoader.LoadImageAsync(uri);
+            while (cor.MoveNext())
+            {
+                yield return null;
+            }
+
+            // ResourceLoader.LoadImageAsyncが完了した段階で読み込み完了
+            // もう一度同一uriのリクエストが行われた場合、ResourceLoader側が画像をキャッシュしているので
+            // IEnumeratorは即座に完了する
+            downloadingUris.Remove(uri);
+        }
+
+        // downloadingUrisが1以上ならDefaultImageDownloaderは画像読み込み処理を行っている
+        public bool IsRunning()
+        {
+            return downloadingUris.Count > 0;
+        }
+
+        public void Reset()
+        {
+            downloadingUris.Clear();
+        }
+    };
+}

--- a/Assets/UUebView/Core/DefaultImageDownloader.cs.meta
+++ b/Assets/UUebView/Core/DefaultImageDownloader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb56e350b13275545b397c4a36f1deb4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UUebView/Tests/HTMLParserTests.cs
+++ b/Assets/UUebView/Tests/HTMLParserTests.cs
@@ -16,7 +16,7 @@ public class HTMLParserTests : MiyamasuTestRunner
     private HTMLParser parser;
 
     private ResourceLoader loader;
-
+    private DefaultImageDownloader defaultImageDownloader;
     private UUebView.UUebViewComponent executor;
 
     [MSetup]
@@ -27,8 +27,9 @@ public class HTMLParserTests : MiyamasuTestRunner
         var core = new UUebView.UUebViewCore(executor);
         executor.SetCore(core);
         loader = new ResourceLoader(executor.Core.CoroutineExecutor);
+        defaultImageDownloader = new DefaultImageDownloader(executor.Core.CoroutineExecutor, loader);
 
-        parser = new HTMLParser(loader);
+        parser = new HTMLParser(loader, defaultImageDownloader);
     }
 
     [MTeardown]

--- a/Assets/UUebView/Tests/LayoutMachineTests.cs
+++ b/Assets/UUebView/Tests/LayoutMachineTests.cs
@@ -16,6 +16,7 @@ public class LayoutMachineTests : MiyamasuTestRunner
     private HTMLParser parser;
 
     private ResourceLoader loader;
+    private DefaultImageDownloader defaultImageDownloader;
 
     private UUebView.UUebViewComponent executor;
 
@@ -37,8 +38,9 @@ public class LayoutMachineTests : MiyamasuTestRunner
         executor.SetCore(core);
 
         loader = new ResourceLoader(executor.Core.CoroutineExecutor);
+        defaultImageDownloader = new DefaultImageDownloader(executor.Core.CoroutineExecutor, loader);
 
-        parser = new HTMLParser(loader);
+        parser = new HTMLParser(loader, defaultImageDownloader);
     }
 
     [MTeardown]

--- a/Assets/UUebView/Tests/MaterializeMachineTests.cs
+++ b/Assets/UUebView/Tests/MaterializeMachineTests.cs
@@ -61,7 +61,7 @@ public class MaterializeMachineTests : MiyamasuTestRunner
         rectTrans.anchoredPosition = new Vector2(100 * index, 0);
         index++;
 
-        parser = new HTMLParser(core.resLoader);
+        parser = new HTMLParser(core.resLoader, core.defaultImageDownloader);
     }
 
     private IEnumerator CreateLayoutedTree(string sampleHtml, Action<TagTree> onLayouted, float width = 100)

--- a/Assets/UUebView/Tests/TMProExtensionMaterializeMachineTests.cs
+++ b/Assets/UUebView/Tests/TMProExtensionMaterializeMachineTests.cs
@@ -62,7 +62,7 @@ public class TMProExtensionMaterializeMachineTests : MiyamasuTestRunner
         rectTrans.anchoredPosition = new Vector2(100 * index, 0);
         index++;
 
-        parser = new HTMLParser(core.resLoader);
+        parser = new HTMLParser(core.resLoader, core.defaultImageDownloader);
     }
 
     private IEnumerator CreateLayoutedTree(string sampleHtml, Action<TagTree> onLayouted, float width = 100)


### PR DESCRIPTION
To know image-size, LayoutMachine downloads images synchronously when it found `<img>` tags.
refer to https://github.com/sassembla/UUebView/blob/master/Assets/UUebView/Core/LayoutMachine.cs#L421-L459

If many `<img>` tags are used, it takes a long time to display UUebView.
Added DefaultImageDownloader to download images asynchronously when HTMLParser found <img> tags.
